### PR TITLE
Fix build on pnpm

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "esnext",
     "esModuleInterop": true,
     "sourceMap": false,
     "rootDirs": ["src", "test"],


### PR DESCRIPTION
https://github.com/johman10/ntfy-browser/pull/3#issuecomment-2081541694


<details>
	<summary>Build errors in question</summary>

```
❯ git remote -v
origin  git@github.com:rockbenben/ntfy-browser.git (fetch)
origin  git@github.com:rockbenben/ntfy-browser.git (push)

❯ git stash
Saved working directory and index state WIP on master: 6d644ce ci: upgrade dependencies in build.yml

❯ git remote set-url origin git@github.com:johman10/ntfy-browser.git

❯ git pull
remote: Enumerating objects: 44, done.
remote: Counting objects: 100% (44/44), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 28 (delta 18), reused 23 (delta 15), pack-reused 0
Unpacking objects: 100% (28/28), 58.66 KiB | 612.00 KiB/s, done.
From github.com:johman10/ntfy-browser
 + 6d644ce...ec7271a master     -> origin/master  (forced update)
Successfully rebased and updated refs/heads/master.

❯ git clean -xdf
Removing dist/
Removing node_modules/
Removing web-ext-artifacts/

❯ pnpm i
 WARN  3 deprecated subdependencies found: har-validator@5.1.5, request@2.88.2, uuid@3.4.0
Packages: +920
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 920, reused 889, downloaded 30, added 920, done
node_modules/.pnpm/dtrace-provider@0.8.8/node_modules/dtrace-provider: Running install script, done in 11.4s
node_modules/.pnpm/spawn-sync@1.0.15/node_modules/spawn-sync: Running postinstall script, done in 83ms

dependencies:
+ @emotion/react 11.11.4
+ @emotion/styled 11.11.5
+ @mui/icons-material 5.15.15
+ @mui/lab 5.0.0-alpha.170
+ @mui/material 5.15.15
+ react 18.3.1
+ react-dom 18.3.1
+ react-hook-form 7.51.3

devDependencies:
+ @types/chrome 0.0.267
+ @types/jest 29.5.12
+ @types/react 18.3.1
+ @types/react-dom 18.3.0
+ @types/webextension-polyfill 0.10.7
+ @typescript-eslint/eslint-plugin 7.7.1
+ @typescript-eslint/parser 7.7.1
+ copy-webpack-plugin 12.0.2
+ cross-env 7.0.3
+ eslint 8.57.0 (9.1.1 is available)
+ eslint-plugin-react 7.34.1
+ jest 29.7.0
+ prettier 3.2.5
+ rimraf 5.0.5
+ ts-jest 29.1.2
+ ts-loader 9.5.1
+ typescript 5.4.5
+ web-ext 7.11.0
+ webextension-polyfill 0.11.0
+ webpack 5.91.0
+ webpack-cli 5.1.4
+ webpack-merge 5.10.0
+ wext-manifest-loader 3.0.0
+ wext-manifest-webpack-plugin 1.4.1

 WARN  Issues with peer dependencies found
.
└─┬ web-ext 7.11.0
  └─┬ addons-linter 6.21.0
    └─┬ addons-scanner-utils 9.9.0
      └── ✕ unmet peer node-fetch@2.6.11: found 3.3.1 in web-ext

Done in 37.1s

❯ pnpm run build

> ntfy-browser@1.0.0 build ~\Documents\GitHub\ntfy-browser
> npm run build:chrome && npm run build:firefox


> ntfy-browser@1.0.0 build:chrome
> cross-env TARGET_BROWSER=chrome webpack --config webpack/webpack.prod.js && web-ext build --source-dir ./dist/chrome --artifacts-dir dist --filename ntfy-browser-chrome.zip

wext-manifest-webpack-plugin: removed manifest.js
assets by status 832 KiB [cached] 25 assets
Entrypoint manifest = 1 auxiliary asset
Entrypoint js/popup = js/popup.js
Entrypoint js/options = js/options.js
Entrypoint js/background = js/background.js
orphan modules 2.07 MiB [orphan] 930 modules
runtime modules 3.18 KiB 7 modules
cacheable modules 2.01 MiB
  modules by path ./node_modules/.pnpm/ 1.98 MiB 115 modules
  modules by path ./src/ 25.9 KiB
    modules by path ./src/utils/ 14.9 KiB
      modules with errors 78 bytes [errors] 2 modules
      + 6 modules
    modules by path ./src/components/ 4.48 KiB 8 modules
    modules by path ./src/*.tsx 4.11 KiB
      ./src/popup.tsx 4.07 KiB [built] [code generated]
      ./src/options.tsx 39 bytes [built] [code generated] [1 error]
    ./src/manifest.json 59 bytes [built] [code generated]
    ./src/background.ts 2.31 KiB [built] [code generated]

ERROR in ./src/components/NotificationCard/NotificationCard.tsx
Module build failed (from ./node_modules/.pnpm/ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_/node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for ~\Documents\GitHub\ntfy-browser\src\components\NotificationCard\NotificationCard.tsx.
    at makeSourceMapAndFinish (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:55:18)
    at successLoader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:42:5)
    at Object.loader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:23:5)
 @ ./src/components/NotificationCard/index.ts 7:25-54
 @ ./src/components/PopupContent/PopupContent.tsx 6:43-73
 @ ./src/components/PopupContent/index.ts 7:21-46
 @ ./src/popup.tsx 35:39-75

ERROR in ./src/options.tsx
Module build failed (from ./node_modules/.pnpm/ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_/node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for ~\Documents\GitHub\ntfy-browser\src\options.tsx.
    at makeSourceMapAndFinish (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:55:18)
    at successLoader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:42:5)
    at Object.loader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:23:5)

ERROR in ./src/utils/TopicSubscriptionManager.ts
Module build failed (from ./node_modules/.pnpm/ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_/node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for ~\Documents\GitHub\ntfy-browser\src\utils\TopicSubscriptionManager.ts.
    at makeSourceMapAndFinish (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:55:18)
    at successLoader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:42:5)
    at Object.loader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:23:5)
 @ ./src/background.ts 18:51-94

ERROR in ./src/utils/messages/BackgroundMessageHandler.ts
Module build failed (from ./node_modules/.pnpm/ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_/node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for ~\Documents\GitHub\ntfy-browser\src\utils\messages\BackgroundMessageHandler.ts.
    at makeSourceMapAndFinish (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:55:18)
    at successLoader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:42:5)
    at Object.loader (~\Documents\GitHub\ntfy-browser\node_modules\.pnpm\ts-loader@9.5.1_typescript@5.4.5_webpack@5.91.0_webpack-cli@5.1.4_\node_modules\ts-loader\dist\index.js:23:5)
 @ ./src/background.ts 19:51-103

ERROR in ~\Documents\GitHub\ntfy-browser\__mocks__\webextension-polyfill.ts
59:40-48
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\__mocks__\webextension-polyfill.ts(59,41)
      TS2550: Property 'includes' does not exist on type '((notificationId: string) => void)[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2016' or later.

ERROR in ~\Documents\GitHub\ntfy-browser\src\options.tsx
./src/options.tsx 96:9-16
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\options.tsx(96,10)
      TS2550: Property 'finally' does not exist on type 'Promise<void>'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

ERROR in ~\Documents\GitHub\ntfy-browser\src\components\NotificationCard\NotificationCard.tsx
./src/components/NotificationCard/NotificationCard.tsx 70:4-13
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\components\NotificationCard\NotificationCard.tsx(70,5)
      TS2353: Object literal may only specify known properties, and 'dateStyle' does not exist in type 'DateTimeFormatOptions'.
 @ ./src/components/NotificationCard/index.ts 7:25-54
 @ ./src/components/PopupContent/PopupContent.tsx 6:43-73
 @ ./src/components/PopupContent/index.ts 7:21-46
 @ ./src/popup.tsx 35:39-75

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\TopicSubscriptionManager.ts
./src/utils/TopicSubscriptionManager.ts 71:31-39
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\TopicSubscriptionManager.ts(71,32)
      TS2550: Property 'includes' does not exist on type 'EventSource[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2016' or later.
 @ ./src/background.ts 18:51-94

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\TopicSubscriptionManager.ts
./src/utils/TopicSubscriptionManager.ts 84:35-41
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\TopicSubscriptionManager.ts(84,36)
      TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
 @ ./src/background.ts 18:51-94

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts
4:22-33
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts(4,23)
      TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts
5:12-19
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts(5,13)
      TS2550: Property 'flatMap' does not exist on type '{ emoji: string; aliases: string[]; tags: string[]; category: string; description: string; unicode_version: string; }[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts
5:21-26
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts(5,22)
      TS7006: Parameter 'emoji' implicitly has an 'any' type.

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts
6:23-28
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\emojis\emojisMapped.ts(6,24)
      TS7006: Parameter 'alias' implicitly has an 'any' type.

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\messages\BackgroundMessageHandler.ts
./src/utils/messages/BackgroundMessageHandler.ts 36:9-22
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\messages\BackgroundMessageHandler.ts(36,10)
      TS7006: Parameter 'eventResponse' implicitly has an 'any' type.
 @ ./src/background.ts 19:51-103

ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\messages\BackgroundMessageHandler.ts
./src/utils/messages/BackgroundMessageHandler.ts 41:16-29
[tsl] ERROR in ~\Documents\GitHub\ntfy-browser\src\utils\messages\BackgroundMessageHandler.ts(41,17)
      TS7006: Parameter 'eventResponse' implicitly has an 'any' type.
 @ ./src/background.ts 19:51-103

11 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.91.0 compiled with 15 errors in 16295 ms
 ELIFECYCLE  Command failed with exit code 1.

❯ git stash show -p
diff --git a/tsconfig.json b/tsconfig.json
index a625c16..ed97093 100644
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "esnext",
     "esModuleInterop": true,
     "sourceMap": false,
     "rootDirs": ["src", "test"],

❯ git stash pop
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   tsconfig.json

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (ae545fe429a0394efafea871fe13b60304557ed5)

❯ pnpm run build

> ntfy-browser@1.0.0 build ~\Documents\GitHub\ntfy-browser
> npm run build:chrome && npm run build:firefox


> ntfy-browser@1.0.0 build:chrome
> cross-env TARGET_BROWSER=chrome webpack --config webpack/webpack.prod.js && web-ext build --source-dir ./dist/chrome --artifacts-dir dist --filename ntfy-browser-chrome.zip

wext-manifest-webpack-plugin: removed manifest.js
assets by path icons/*.svg 4.61 KiB 5 assets
assets by path *.png 32.8 KiB 4 assets
assets by path fonts/*.woff2 61.7 KiB 4 assets
assets by path js/*.js 1.68 MiB 3 assets
assets by path *.svg 8 KiB 3 assets
assets by path css/*.css 1.02 KiB
  asset css/fonts.css 917 bytes [emitted] [from: public/css/fonts.css] [copied]
  asset css/app.css 124 bytes [emitted] [from: public/css/app.css] [copied]
assets by path *.html 951 bytes
  asset options.html 616 bytes [emitted] [from: public/options.html] [copied]
  asset popup.html 335 bytes [emitted] [from: public/popup.html] [copied]
asset _locales/en/messages.json 4.87 KiB [emitted] [from: public/_locales/en/messages.json] [copied]
asset manifest.json 556 bytes [emitted] (auxiliary name: manifest)
Entrypoint manifest (556 bytes) = 1 auxiliary asset
Entrypoint js/popup [big] 929 KiB = js/popup.js
Entrypoint js/options [big] 770 KiB = js/options.js
Entrypoint js/background 17.5 KiB = js/background.js
orphan modules 1.73 MiB [orphan] 951 modules
runtime modules 5.21 KiB 12 modules
cacheable modules 2.49 MiB
  modules by path ./node_modules/.pnpm/ 2.11 MiB 213 modules
  modules by path ./src/ 393 KiB
    modules by path ./src/utils/ 364 KiB 12 modules
    modules by path ./src/components/ 15.4 KiB 12 modules
    modules by path ./src/*.tsx 10.9 KiB
      ./src/popup.tsx 4.07 KiB [built] [code generated]
      ./src/options.tsx 6.85 KiB [built] [code generated]
    ./src/manifest.json 59 bytes [built] [code generated]
    ./src/background.ts 1.55 KiB [built] [code generated]
    ./src/types/extension.ts 446 bytes [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  js/popup.js (929 KiB)
  js/options.js (770 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  js/popup (929 KiB)
      js/popup.js
  js/options (770 KiB)
      js/options.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.91.0 compiled with 3 warnings in 18234 ms
Applying config file: .\package.json
Building web extension from ~\Documents\GitHub\ntfy-browser\dist\chrome
Your web extension is ready: dist\ntfy-browser-chrome.zip

> ntfy-browser@1.0.0 build:firefox
> cross-env TARGET_BROWSER=firefox webpack --config webpack/webpack.prod.js && web-ext build --source-dir ./dist/firefox --artifacts-dir dist --filename ntfy-browser-firefox.zip

wext-manifest-webpack-plugin: removed manifest.js
assets by path icons/*.svg 4.61 KiB 5 assets
assets by path *.png 32.8 KiB 4 assets
assets by path fonts/*.woff2 61.7 KiB 4 assets
assets by path js/*.js 1.68 MiB 3 assets
assets by path *.svg 8 KiB 3 assets
assets by path css/*.css 1.02 KiB
  asset css/fonts.css 917 bytes [emitted] [from: public/css/fonts.css] [copied]
  asset css/app.css 124 bytes [emitted] [from: public/css/app.css] [copied]
assets by path *.html 951 bytes
  asset options.html 616 bytes [emitted] [from: public/options.html] [copied]
  asset popup.html 335 bytes [emitted] [from: public/popup.html] [copied]
asset _locales/en/messages.json 4.87 KiB [emitted] [from: public/_locales/en/messages.json] [copied]
asset manifest.json 691 bytes [emitted] (auxiliary name: manifest)
Entrypoint manifest (691 bytes) = 1 auxiliary asset
Entrypoint js/popup [big] 929 KiB = js/popup.js
Entrypoint js/options [big] 770 KiB = js/options.js
Entrypoint js/background 17.5 KiB = js/background.js
orphan modules 1.73 MiB [orphan] 951 modules
runtime modules 5.21 KiB 12 modules
cacheable modules 2.49 MiB
  modules by path ./node_modules/.pnpm/ 2.11 MiB 213 modules
  modules by path ./src/ 393 KiB
    modules by path ./src/utils/ 364 KiB 12 modules
    modules by path ./src/components/ 15.4 KiB 12 modules
    modules by path ./src/*.tsx 10.9 KiB
      ./src/popup.tsx 4.07 KiB [built] [code generated]
      ./src/options.tsx 6.85 KiB [built] [code generated]
    ./src/manifest.json 59 bytes [built] [code generated]
    ./src/background.ts 1.55 KiB [built] [code generated]
    ./src/types/extension.ts 446 bytes [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  js/popup.js (929 KiB)
  js/options.js (770 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  js/popup (929 KiB)
      js/popup.js
  js/options (770 KiB)
      js/options.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.91.0 compiled with 3 warnings in 18181 ms
Applying config file: .\package.json
Building web extension from ~\Documents\GitHub\ntfy-browser\dist\firefox
Your web extension is ready: dist\ntfy-browser-firefox.zip
```
</details>